### PR TITLE
Update Merger.php to compare strict type for checkbox true situation

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1573,7 +1573,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
           4 => NULL,
           5 => $value,
           'is_checked' => $isChecked,
-          ];
+        ];
       }
 
       $migrationInfo["move_$field"] = $value;
@@ -2766,7 +2766,7 @@ ORDER BY civicrm_custom_group.weight,
     ];
     return $keysToIgnore[$type];
   }
-  
+
   /**
    * Get the field value & label for the given field.
    *

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1544,7 +1544,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
       $rows["move_$field"] = [
         'main' => self::getFieldValueAndLabel($field, $main, $checkPermissions)['label'],
         'other' => self::getFieldValueAndLabel($field, $other, $checkPermissions)['label'],
-        'title' => $fields[$field]['label'] . (in_array($field, self::useLatestValueFields()) ? ' (prioritize latest option)' : ''),
+        'title' => $fields[$field]['label'],
       ];
 
       $value = self::getFieldValueAndLabel($field, $other, $checkPermissions)['value'];
@@ -1572,7 +1572,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
           3 => NULL,
           4 => NULL,
           5 => $value,
-          'is_checked' => in_array($field, self::useLatestValueFields()) ? TRUE : $isChecked,
+          'is_checked' => $isChecked,
           ];
       }
 
@@ -2558,8 +2558,6 @@ ORDER BY civicrm_custom_group.weight,
             || ($migrationInfo['rows'][$key]['main'] === '0' && substr($key, 0, 12) === 'move_custom_')
           )
           && $migrationInfo['rows'][$key]['main'] != $migrationInfo['rows'][$key]['other']
-          // no need to mark $keysToUseLatest as conflict, will force to use the latest value
-          && !in_array(substr($key, 5), self::useLatestValueFields())
         ) {
 
           // note it down & lets wait for response from the hook.
@@ -2767,21 +2765,6 @@ ORDER BY civicrm_custom_group.weight,
       ],
     ];
     return $keysToIgnore[$type];
-  }
-
-  /**
-   * default use latest value no need to double check, based on ticket T345206
-   * @param string $type
-   * @return array
-   */
-  protected static function useLatestValueFields(string $type = 'contact'): array {
-    $keysToUseLatest = [
-      'contact' => [
-        // T345206 prioritize the option from the latest CID over the older one
-        'is_opt_out',
-      ],
-    ];
-    return $keysToUseLatest[$type];
   }
   
   /**


### PR DESCRIPTION
Update Merger.php to compare strict type for checkbox true situation

Overview
----------------------------------------
If try to Manual merge two Individual contacts, and those contacts have different Is Opt Out value
currently, no checkbox under the column "Mark All"

Before
----------------------------------------
Currently no checkbox for Opt Out value,
like https://civicrm.wikimedia.org/civicrm/contact/merge?reset=1&action=update&cid=205&oid=61133966
<img width="1075" alt="Screenshot 2023-11-07 at 2 16 26 PM" src="https://github.com/wikimediaWfan/civicrm-core/assets/96108825/33dfe278-bb7b-45a3-9349-59f8f629071c">

After
----------------------------------------
After this patch, you will able to see the checkbox for this field if values are different

Technical Details
----------------------------------------
Update Merger.php to compare strict type for checkbox true situation

Comments
----------------------------------------
for users to have ability to check/uncheck overwrite for Is Opt Out when merge
